### PR TITLE
v0.1.9

### DIFF
--- a/assets/FOOTER.html
+++ b/assets/FOOTER.html
@@ -3,7 +3,7 @@
     </section>
     <footer id="section-footer">
         <div class="row">
-            <p>Apache Fancy Pages v0.1.8 | © 2021 Christophe Buliard | <a target="_blank" href="https://github.com/kristuff/apache-fancy-pages" rel="no-referer">Source code</a> </p> 
+            <p>Apache Fancy Pages v0.1.9 | © 2021-2022 Christophe Buliard | <a target="_blank" href="https://github.com/kristuff/apache-fancy-pages" rel="no-referer">Source code</a> </p> 
         </div>
     </footer>
     <script src="/fancy-pages/js/script.js"></script>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -6,7 +6,7 @@
  *                  |__/         |___/
  * 
  * This file is part of kristuff/apache-fancy-pages.
- * Version 0.1.8 - Copyright (c) 2021 Kristuff <kristuff@kristuff.fr>
+ * v0.1.9 - Copyright (c) 2021-2022 Kristuff <kristuff@kristuff.fr>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/assets/error/401.html
+++ b/assets/error/401.html
@@ -106,7 +106,7 @@
 <body>
     <div class="container">
         <div class="content">
-            <h1><span class="emoj">:(</span>401 Unauthorized</h3>
+            <h1><span class="emoj">:(</span>401 Unauthorized</h1>
             <hr/>
             <h3>This server could not verify that you are authorized to access the document requested. Either you supplied the wrong credentials (e.g., bad password), or your browser doesn't understand how to supply the credentials required.</h3>
         </div>

--- a/assets/error/403.html
+++ b/assets/error/403.html
@@ -105,7 +105,7 @@
 <body>
     <div class="container">
         <div class="content">
-            <h1><span class="emoj">:(</span>403 Forbidden</h3>
+            <h1><span class="emoj">:(</span>403 Forbidden</h1>
             <hr/>
             <h3>You don't have permission to access this resource.</h3>
         </div>

--- a/assets/error/404.html
+++ b/assets/error/404.html
@@ -105,7 +105,7 @@
 <body>
     <div class="container">
         <div class="content">
-            <h1> <span class="emoj">:(</span>404 Not Found</h3>
+            <h1> <span class="emoj">:(</span>404 Not Found</h1>
             <h3>The page you're looking for could not be found.</h3>
             <hr/>
             <p>Make sure the address is correct and that the page hasn't moved.</p>

--- a/assets/error/500.html
+++ b/assets/error/500.html
@@ -105,7 +105,7 @@
 <body>
     <div class="container">
         <div class="content">
-            <h1> <span class="emoj">:(</span>500 Internal Server Error</h3>
+            <h1> <span class="emoj">:(</span>500 Internal Server Error</h1>
             <h3>Whoops, something went wrong on our end.</h3>
             <hr/>
             <p>Try refreshing the page, or going back and attempting the action again.</p>

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -6,7 +6,7 @@
  *                  |__/         |___/
  * 
  * This file is part of kristuff/apache-fancy-pages.
- * Version 0.1.8 - Copyright (c) 2021 Kristuff <kristuff@kristuff.fr>
+ * v0.1.9 - Copyright (c) 2021-2022 Kristuff <kristuff@kristuff.fr>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/conf/fancy-error.conf
+++ b/conf/fancy-error.conf
@@ -5,15 +5,15 @@
 #                  |__/         |___/
 # 
 # This file is part of kristuff/apache-fancy-pages.
-# Version 0.1.8
-# Copyright (c) 2021 Kristuff <kristuff@kristuff.fr>
+# Version 0.1.9
+# Copyright (c) 2021-2022 Kristuff <kristuff@kristuff.fr>
 #
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
 
 
 # [fancy-error.conf]
-#   Depends: Apache >= 2.4
+#   requires: Apache >= 2.4
 #   
 #   Deploy fancy-error globaly:
 #   Set ErrorDocument to custom templates and

--- a/conf/fancy-index-tests.conf
+++ b/conf/fancy-index-tests.conf
@@ -5,15 +5,15 @@
 #                  |__/         |___/
 # 
 # This file is part of kristuff/apache-fancy-pages.
-# Version 0.1.8
-# Copyright (c) 2021 Kristuff <kristuff@kristuff.fr>
+# Version 0.1.9
+# Copyright (c) 2021-2022 Kristuff <kristuff@kristuff.fr>
 #
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
 
 
 # [fancy-index-tests.conf]
-#   Depends: Apache >= 2.4, [fancy-index.conf]
+#   Requires: Apache >= 2.4, [fancy-index.conf]
 #   
 #   Enable directory listings for /fancy-index-tests/
 #   Contains empty files with various extensions for testing.

--- a/conf/fancy-index.conf
+++ b/conf/fancy-index.conf
@@ -5,15 +5,15 @@
 #                  |__/         |___/
 # 
 # This file is part of kristuff/apache-fancy-pages.
-# Version 0.1.8
-# Copyright (c) 2021 Kristuff <kristuff@kristuff.fr>
+# Version 0.1.9
+# Copyright (c) 2021-2022 Kristuff <kristuff@kristuff.fr>
 #
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
 
 
 # [fancy-pages.conf]
-#   Depends: Apache >= 2.4
+#   Requires Apache >= 2.4
 #   
 #   Deploy fancy-index globaly:
 #   Create Alias /fancy-pages to serve assets files and define template (header and

--- a/create_package.sh
+++ b/create_package.sh
@@ -7,8 +7,7 @@
 #                  |__/         |___/
 # 
 # This file is part of kristuff/apache-fancy-pages.
-# Version 0.1.8
-# Copyright (c) 2021 Kristuff <kristuff@kristuff.fr>
+# v0.1.9 - Copyright (c) 2021-2022 Kristuff <kristuff@kristuff.fr>
 #
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
@@ -22,26 +21,42 @@ rm -rf debian
 mkdir -p debian/DEBIAN
 mkdir -p debian/usr/share/apache-fancy-pages
 mkdir -p debian/usr/share/doc/apache-fancy-pages
+mkdir -p debian/usr/share/man/man5
 mkdir -p debian/etc/apache2/conf-available
 
 # populate the debian directory
 cp deb/control                  debian/DEBIAN
+cp deb/conffiles                debian/DEBIAN
 cp deb/copyright                debian/usr/share/doc/apache-fancy-pages
+cp deb/changelog                debian/usr/share/doc/apache-fancy-pages/changelog.Debian
+gzip -9 -n                      debian/usr/share/doc/apache-fancy-pages/changelog.Debian  
+cp deb/changelog                debian/usr/share/doc/apache-fancy-pages/changelog
+gzip -9 -n                      debian/usr/share/doc/apache-fancy-pages/changelog  
 cp -R tests                     debian/usr/share/doc/apache-fancy-pages
+
 cp -R assets/css                debian/usr/share/apache-fancy-pages
 cp -R assets/js                 debian/usr/share/apache-fancy-pages
 cp -R assets/icons              debian/usr/share/apache-fancy-pages
 cp assets/*.html                debian/usr/share/apache-fancy-pages
 cp -R assets/error              debian/usr/share/apache-fancy-pages
+
 cp conf/fancy-index.conf        debian/etc/apache2/conf-available
 cp conf/fancy-index-tests.conf  debian/etc/apache2/conf-available
 cp conf/fancy-error.conf        debian/etc/apache2/conf-available
 
-# adjust ownerships
-chown -R root:root              debian
-chown -R root:root              debian/usr/share/apache-fancy-pages
-chmod -R 0755                   debian/usr/share/apache-fancy-pages
-chmod -R 0644                   debian/etc 
+# convert and deploy man page
+/usr/bin/pandoc --standalone --to man deb/man-fancy-index.md -o debian/usr/share/man/man5/fancy-index.conf.5 
+gzip -9 -n debian/usr/share/man/man5/fancy-index.conf.5 
+
+/usr/bin/pandoc --standalone --to man deb/man-fancy-index-tests.md -o debian/usr/share/man/man5/fancy-index-tests.conf.5 
+gzip -9 -n debian/usr/share/man/man5/fancy-index-tests.conf.5 
+
+/usr/bin/pandoc --standalone --to man deb/man-fancy-error.md -o debian/usr/share/man/man5/fancy-error.conf.5 
+gzip -9 -n debian/usr/share/man/man5/fancy-error.conf.5 
+
+# adjust permissions
+find debian -type d -exec chmod 0755 {} \;          #set directory attributes
+find debian -type f -exec chmod 0644 {} \;          #set data file attributes
 
 # finally build the package
-dpkg-deb --build debian dist
+dpkg-deb --root-owner-group --build debian dist

--- a/deb/changelog
+++ b/deb/changelog
@@ -1,0 +1,19 @@
+apache-fancy-pages (0.1.9-2) unstable; urgency=medium
+
+  * man page missing
+
+ -- kristuff <kristuff@kristuff.fr>  Wed, 12 Jan 2022 19:30:00 +0200
+
+apache-fancy-pages (0.1.9) unstable; urgency=medium
+
+  * Fix wrong closing heading tag in error templates
+  * Apache conf files under /etc now marked as conffiles
+  * Added man pages for conf files
+
+ -- kristuff <kristuff@kristuff.fr>  Wed, 12 Jan 2022 19:00:00 +0200
+
+apache-fancy-pages (0.1.8) unstable; urgency=medium
+
+  * Initial release
+
+ -- kristuff <kristuff@kristuff.fr>  Thu, 26 Aug 2021 19:00:00 +0200

--- a/deb/conffiles
+++ b/deb/conffiles
@@ -1,0 +1,3 @@
+/etc/apache2/conf-available/fancy-index.conf
+/etc/apache2/conf-available/fancy-index-tests.conf
+/etc/apache2/conf-available/fancy-error.conf

--- a/deb/control
+++ b/deb/control
@@ -1,8 +1,9 @@
 Package: apache-fancy-pages
-Version: 0.1.8
+Version: 0.1.9-2
 Maintainer: kristuff <kristuff@kristuff.fr>
 Architecture: all
 Depends: apache2
-Description: Responsive Apache2 index/error pages.
+Description: Responsive Apache2 index/error pages
+ Modern drop in replacement for default Apache index/error pages.
 Priority: optional
 Section: utils

--- a/deb/copyright
+++ b/deb/copyright
@@ -3,10 +3,5 @@ Upstream-Name: Apache Fancy Pages
 Upstream-Contact: kristuff <kristuff@kristuff.fr>
 
 Files: *
-Copyright: 2021 Kristuff <kristuff@kristuff.fr>
-License: GPL-3.0 License 
- This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, version 3.
- .
- This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
- .   
- You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>. 
+Copyright: 2021-2022 Kristuff <kristuff@kristuff.fr>
+License: GPL-3

--- a/deb/man-fancy-error.md
+++ b/deb/man-fancy-error.md
@@ -1,0 +1,34 @@
+% FANCY-ERROR.CONF(5) Apache-fancy-pages User Manuals
+% 
+% Janury 12, 2022
+
+# NAME
+
+fancy-error.conf - configuration file for apache-fancy-pages.
+
+# SYNOPSIS
+
+fancy-error.conf
+
+# DESCRIPTION
+
+The **fancy-error.conf** defines *ErrorDocument* to custom templates.
+
+Enable this conf to serve custom default pages instead of default Apache pages. 
+
+~~~~~~~
+a2enconf fancy-error
+systemctl reload apache2
+~~~~~~~
+
+
+# BUGS
+
+Submit bug reports online at: <https://github.com/kristuff/apache-fancy-pages/issues>
+
+# SEE ALSO
+
+Source code at: <https://github.com/kristuff/apache-fancy-pages>
+
+Online documentation at: <https://kristuff.fr/projects/apache-fancy-pages/>
+

--- a/deb/man-fancy-index-tests.md
+++ b/deb/man-fancy-index-tests.md
@@ -1,0 +1,34 @@
+% FANCY-INDEX-TESTS.CONF(5) Apache-fancy-pages User Manuals
+% 
+% Janury 12, 2022
+
+# NAME
+
+fancy-index-tests.conf - configuration file for apache-fancy-pages.
+
+# SYNOPSIS
+
+fancy-index-texts.conf
+
+# DESCRIPTION
+
+The **fancy-index-tests.conf** contains an alias for url */fancy-index-tests* designed to test **fancy-index.conf**. It exposes a directory containing empty files with various extensions. 
+
+Enable this conf in addition to *fancy-index* to allow indexing on url */fancy-index-tests*.
+
+~~~~~~~
+a2enconf fancy-index
+a2enconf fancy-index-tests
+systemctl reload apache2
+~~~~~~~
+
+# BUGS
+
+Submit bug reports online at: <https://github.com/kristuff/apache-fancy-pages/issues>
+
+# SEE ALSO
+
+Source code at: <https://github.com/kristuff/apache-fancy-pages>
+
+Online documentation at: <https://kristuff.fr/projects/apache-fancy-pages/>
+

--- a/deb/man-fancy-index.md
+++ b/deb/man-fancy-index.md
@@ -1,0 +1,33 @@
+% FANCY-INDEX.CONF(5) Apache-fancy-pages User Manuals
+% 
+% Janury 12, 2022
+
+# NAME
+
+fancy-index.conf - configuration file for apache-fancy-pages.
+
+# SYNOPSIS
+
+fancy-index.conf
+
+# DESCRIPTION
+
+The **fancy-index.conf** contains an alias for url /fancy-pages to serve template, style, script and icons files. 
+
+Enable this conf to set fancy-index enabled everywhere Options Indexes is enabled.
+
+~~~~~~~
+a2enconf fancy-index
+systemctl reload apache2
+~~~~~~~
+
+# BUGS
+
+Submit bug reports online at: <https://github.com/kristuff/apache-fancy-pages/issues>
+
+# SEE ALSO
+
+Source code at: <https://github.com/kristuff/apache-fancy-pages>
+
+Online documentation at: <https://kristuff.fr/projects/apache-fancy-pages/>
+


### PR DESCRIPTION
**Changes**
- Fix wrong closing heading tag in error templates
- `.deb` package: conf files under /etc now marked as conffiles, added man pages for conf files, changelog